### PR TITLE
Fixing typos

### DIFF
--- a/7-eeg/mne_data.ipynb
+++ b/7-eeg/mne_data.ipynb
@@ -592,7 +592,7 @@
    "id": "f2d2df57-9392-47d3-bdb9-a935733c39c3",
    "metadata": {},
    "source": [
-    "One challenge in working with the raw data directly in this way, is that we normally think of, and work with, EEG data in terms of units of time, such as seconds or milliseconds. However, EEG data is not always (or even usually) sampled at 1000 Hz, so each time point doesn't correspond to 1 ms. For example, in our current data set, the sampling rate was 500 Hz, so each time point reflects a period of 2 ms. This makes accessing specific time points or time ranges in the data tricky, because if you want, say, the data from 1500-1800 ms in the `raw` data, you would need to first convert those times to seconds (since `sfreq` is in samples per second), oncvert the result to `int` (since division is likely to yield a `float` result), then multiply each of those times by the sampling rate to get the correct indices. While this is not necessarily difficult, it's a bit tricky and prone to error, as well as creating complex code:"
+    "One challenge in working with the raw data directly in this way, is that we normally think of, and work with, EEG data in terms of units of time, such as seconds or milliseconds. However, EEG data is not always (or even usually) sampled at 1000 Hz, so each time point doesn't correspond to 1 ms. For example, in our current data set, the sampling rate was 500 Hz, so each time point reflects a period of 2 ms. This makes accessing specific time points or time ranges in the data tricky, because if you want, say, the data from 1500-1800 ms in the `raw` data, you would need to first convert those times to seconds (since `sfreq` is in samples per second), convert the result to `int` (since division is likely to yield a `float` result), then multiply each of those times by the sampling rate to get the correct indices. While this is not necessarily difficult, it's a bit tricky and prone to error, as well as creating complex code:"
    ]
   },
   {
@@ -1252,7 +1252,7 @@
    "source": [
     "## Event codes (markers/triggers)\n",
     "\n",
-    "Yes, there are (at least) three names for the codes that mark events in EEG data! *Markers* makes intuitive sense because teh ymark the time of events of interest in the EEG data. *Triggers* is a somewhat old-fashioned term; its origin is obscure but perhaps reflects the idea that stimuli \"trigger\" brain responses that we can measure with EEG. *Event codes* makes sense since they are codes that indicate not only that an event occurred, but it's identity. We'll use *event codes* from this point forward.\n",
+    "Yes, there are (at least) three names for the codes that mark events in EEG data! *Markers* makes intuitive sense because they mark the time of events of interest in the EEG data. *Triggers* is a somewhat old-fashioned term; its origin is obscure but perhaps reflects the idea that stimuli \"trigger\" brain responses that we can measure with EEG. *Event codes* makes sense since they are codes that indicate not only that an event occurred, but it's identity. We'll use *event codes* from this point forward.\n",
     "\n",
     "As noted earlier, the event codes are stored in the `.trg` file in Brain Vision format. When we import the raw data into MNE, these are stored in an attribute called `._annotations`. Although we can access that directly (e.g., `raw._annotations`), again MNE provides tools that makes this easier and generate more interpretable output: the `events_from_annotations()` function:"
    ]
@@ -1446,7 +1446,7 @@
    "id": "7a6730a2-148b-4807-a280-3a45bfe1cbba",
    "metadata": {},
    "source": [
-    "The result includes two outputs, The first is a NumPy array that has three columns, with one row for each event code in the data. The first column indicates the time of the event (in milliseconds, relative tot eh start of the recording), and the last column stores the code associated with that event. These event codes are always represented as integers (since it is a NumPy array of integers). \n",
+    "The result includes two outputs, The first is a NumPy array that has three columns, with one row for each event code in the data. The first column indicates the time of the event (in milliseconds, relative to the start of the recording), and the last column stores the code associated with that event. These event codes are always represented as integers (since it is a NumPy array of integers). \n",
     "\n",
     "The second output is a dictionary mapping labels for each event code, to the numerical codes themselves. Usually these are not very informative in the raw data. In the next lesson, we will learn how to map the numerical codes to meaningful labels based on the experimental design. For now, it's simply important to understand how the event codes are stored in the `Raw` data object."
    ]


### PR DESCRIPTION
'oncvert' -> 'convert'
'teh ymark' -> 'they mark'
'tot eh' -> 'to the'