### PR TITLE
Fixed typo

### DIFF
--- a/2b-setup/vscode.md
+++ b/2b-setup/vscode.md
@@ -48,7 +48,7 @@ In VS Code, click on the "cog" icon in the bottom left, and choose "Settings". C
     "git.path": ""
 }
 ```
-Se the path by putting `/usr/bin/git` between the quotation marks, so that it looks like this:
+Set the path by putting `/usr/bin/git` between the quotation marks, so that it looks like this:
 ```json
 {
     "git.path": "/usr/bin/git"


### PR DESCRIPTION
Fixed typo, was "Se the path" rather than "Set"

Also, you may want to consider updating the Mac git install instructions for something newer (https://git-scm.com/install/mac), as git-osx-installer is abandoned. Though I appreciate how the installer may be simpler to use.